### PR TITLE
OSX Homebrew instruction update

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -20,6 +20,7 @@ Exposes predefined Unicode normalization functions that are required by many pro
     # OSX using Homebrew
     brew install icu4c
     ln -s /usr/local/Cellar/icu4c/<VERSION>/bin/icu-config /usr/local/bin/icu-config
+    ln -s /usr/local/Cellar/icu4c/<VERSION>/include/unicode /usr/local/include
 
     npm install node-stringprep
 


### PR DESCRIPTION
In order for node-gyp to build the unicode libraries need to be in /usr/local/include
