### PR TITLE
StringPrep::prepare: reset `error` before calling usprep_prepare().

### DIFF
--- a/node-stringprep.cc
+++ b/node-stringprep.cc
@@ -122,6 +122,7 @@ protected:
     UChar *dest = NULL;
     while(!dest)
       {
+        error = U_ZERO_ERROR;
         dest = new UChar[destLen];
         size_t w = usprep_prepare(profile,
                                   *str, str.length(),


### PR DESCRIPTION
If the first call to usprep_prepare() returns U_BUFFER_OVERFLOW_ERROR
and the error is not reset, this results in an out-of-memory condition
as all subsequent calls to usprep_prepare() fail without ever setting
`error` to something else.

Here's a test file which can be used to replicate this bug in master:

```
// stringprep-test.js

'use strict';

try {
    var StringPrep = require('./node-stringprep').StringPrep;
    var toUnicode = require('./node-stringprep').toUnicode;
    var c = function (n) {
        var p = new StringPrep(n);
        return function (s) {
            try {
                return p.prepare(s);
            } catch (e) {
                p = new StringPrep(n);
                throw e;
            }
        };
    };
    var nameprep = c('nameprep');
    var nodeprep = c('nodeprep');
    var resourceprep = c('resourceprep');
} catch (ex) {
    console.warn("Cannot load StringPrep-0.1.0 bindings. You may need to `npm install node-stringprep'");
    var identity = function (a) { return a; };
    var toUnicode = identity;
    var nameprep = identity;
    var nodeprep = identity;
    var resourceprep = identity;
}

console.log('nameprep (control): ' + nameprep('chaitanya'));
console.log('nameprep (test): ' + nameprep('bond…007'));
```

When run against master, the output is:

```
nameprep (control): chaitanya
node(41121,0x7fff77d6d180) malloc: *** mmap(size=79164837199872) failed (error code=12)
*** error: can't allocate region
*** set a breakpoint in malloc_error_break to debug
libc++abi.dylib: terminate called throwing an exception
Abort trap: 6
```

When run against this branch, the output is as expected:

```
nameprep (control): chaitanya
nameprep (test): bond...007
```
