### PR TITLE
Options for IDN toUnicode() and toASCII()

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,9 @@
 'use strict';
 
+// from unicode/uidna.h
+var UIDNA_ALLOW_UNASSIGNED = 1
+var UIDNA_USE_STD3_RULES = 2
+
 try {
     var bindings = require('bindings')('node_stringprep.node')
 } catch (ex) {
@@ -11,19 +15,27 @@ try {
     )
 }
 
-var toUnicode = function(value) {
+var toUnicode = function(value, options) {
+    options = options || {}
     try {
-        return bindings.toUnicode(value)
+        return bindings.toUnicode(value,
+            (options.allowUnassigned && UIDNA_ALLOW_UNASSIGNED) | 0)
     } catch (e) {
         return value
     }
 }
 
-var toASCII = function(value) {
+var toASCII = function(value, options) {
+    options = options || {}
     try {
-        return bindings.toASCII(value)
+        return bindings.toASCII(value,
+            (options.allowUnassigned && UIDNA_ALLOW_UNASSIGNED) |
+            (options.useSTD3Rules && UIDNA_USE_STD3_RULES))
     } catch (e) {
-        return value
+        if (options.throwIfError)
+            throw e
+        else
+            return value
     }
 }
 

--- a/node-stringprep.cc
+++ b/node-stringprep.cc
@@ -194,9 +194,11 @@ NAN_METHOD(ToUnicode)
 {
   NanScope();
 
-  if (args.Length() >= 1 && args[0]->IsString())
+  if (args.Length() >= 2 && args[0]->IsString() && args[1]->IsInt32())
   {
     String::Value str(args[0]->ToString());
+    int32_t options = args[1]->ToInt32()->Value();
+
     // ASCII encoding (xn--*--*) should be longer than Unicode
     size_t destLen = str.length() + 1;
     UChar *dest = NULL;
@@ -206,7 +208,7 @@ NAN_METHOD(ToUnicode)
         UErrorCode error = U_ZERO_ERROR;
         size_t w = uidna_toUnicode(*str, str.length(),
                                    dest, destLen,
-                                   UIDNA_DEFAULT,
+                                   options,
                                    NULL, &error);
         
         if (error == U_BUFFER_OVERFLOW_ERROR)
@@ -241,16 +243,17 @@ NAN_METHOD(ToASCII)
 {
   NanScope();
 
-  if (args.Length() >= 1 && args[0]->IsString())
+  if (args.Length() >= 2 && args[0]->IsString() && args[1]->IsInt32())
   {
     String::Value str(args[0]->ToString());
+    int32_t options = args[1]->ToInt32()->Value();
 
     // find out length first
     UErrorCode error = U_ZERO_ERROR;
     size_t strLen = str.length();
     size_t destLen = uidna_toASCII(*str, strLen,
                                    NULL, 0,
-                                   UIDNA_DEFAULT,
+                                   options,
                                    NULL, &error);
     UChar *dest = NULL;
     if (error == U_BUFFER_OVERFLOW_ERROR)
@@ -260,7 +263,7 @@ NAN_METHOD(ToASCII)
         dest = new UChar[destLen];
         uidna_toASCII(*str, strLen,
                       dest, destLen,
-                      UIDNA_DEFAULT,
+                      options,
                       NULL, &error);
       }
     if (U_FAILURE(error))

--- a/test/toascii.js
+++ b/test/toascii.js
@@ -6,7 +6,30 @@ it('Should convert to ASCII', function(done) {
 
     var SP = require('../index')
 
-    var result = SP.toASCII('I\u2665U')
+    var result = SP.toASCII('i\u2665u')
     result.should.equal('xn--iu-t0x')
     done()
+})
+
+it('Should throw on error', function(done) {
+
+	var SP = require('../index')
+	SP.toASCII.bind(SP, '\ud83d\ude03', { throwIfError: true }).should.throw()
+	done()
+})
+
+it('Should convert unassigned code point', function(done) {
+
+	var SP = require('../index')
+
+	var result = SP.toASCII('\ud83d\ude03', { allowUnassigned : true })
+	result.should.equal('xn--h28h')
+	done()
+})
+
+it('Should error on non-STD3 char', function(done) {
+	var SP = require('../index')
+	SP.toASCII.bind(SP, 'abc#def', { throwIfError: true, useSTD3Rules: true }).should.throw()
+	done()
+
 })

--- a/test/tounicode.js
+++ b/test/tounicode.js
@@ -1,0 +1,21 @@
+'use strict';
+
+require('should')
+
+it('Should convert to Unicode', function(done) {
+
+    var SP = require('../index')
+
+    var result = SP.toUnicode('xn--iu-t0x')
+    result.should.equal('i\u2665u')
+    done()
+})
+
+it('Should convert unassigned code point', function(done) {
+
+	var SP = require('../index')
+
+	var result = SP.toUnicode('xn--h28h', { allowUnassigned : true })
+	result.should.equal('\ud83d\ude03')
+	done()
+})


### PR DESCRIPTION
I've added some options for calling `toUnicode` and `toASCII`. Pass an options object as the second param:
- `allowUnassigned` will convert any unassigned Unicode code points (`toUnicode`, `toASCII`).
- `useSTD3Rules` will use the STD3 rules i.e. only a-z, 0-9 and hyphens are allowed (`toASCII`).
- `throwIfError` will throw if an error occurs, instead of just returning the same string (`toASCII`).

The last two options don't apply to `toUnicode` because the underlying `libicu` function does not error on bad input (despite documenting that it does).

I've included unit tests for the essential functionality.
