### PR TITLE
Added additional include path to search within, supporting Mac OS brew u...

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -29,7 +29,7 @@
                 }],
                 ['OS=="mac"', {
                   'include_dirs': [
-                      '/opt/local/include'
+                      '/opt/local/include', '/usr/local/include'
                   ],
                   'xcode_settings': {
                     'GCC_ENABLE_CPP_EXCEPTIONS': 'YES'


### PR DESCRIPTION
This change resolves the issue where the include files for icu4c are not being found. They reside in the brew installed directory of `/usr/local/include/unicode`. The build was only searching in the `/opt/local/include` hierarchy common to MacPorts.

See these issues...
[https://github.com/node-xmpp/node-stringprep/issues/47](https://github.com/node-xmpp/node-stringprep/issues/47)
[https://github.com/node-xmpp/node-stringprep/issues/25](https://github.com/node-xmpp/node-stringprep/issues/25)

error experienced 

```
> node-stringprep@0.5.1 install ./node_modules/node-stringprep
> node-gyp rebuild

  CXX(target) Release/obj.target/node_stringprep/node-stringprep.o
../node-stringprep.cc:2:10: fatal error: 'unicode/unistr.h' file not found
#include <unicode/unistr.h>
         ^
1 error generated.
```
