### PR TITLE
hide warning about stringprep fallbacks in browser

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,13 +9,15 @@ var UIDNA_USE_STD3_RULES = 2
 try {
     var bindings = require('bindings')('node_stringprep.node')
 } catch (ex) {
-    console.warn(
-        'Cannot load StringPrep-' +
-        require('./package.json').version +
-        ' bindings (using fallback). You may need to ' +
-        '`npm install node-stringprep`'
-    )
-    log(ex)
+    if (process.title !== 'browser') {
+        console.warn(
+            'Cannot load StringPrep-' +
+            require('./package.json').version +
+            ' bindings (using fallback). You may need to ' +
+            '`npm install node-stringprep`'
+        )
+        log(ex)
+    }
 }
 
 var toUnicode = function(value, options) {


### PR DESCRIPTION
its possible to load node-stringprep via browserify in the browser, but obviously it only uses the fallbacks.
so lets hide the warning when we're in the browser to lower the console spam.

related to node-xmpp/node-xmpp-client#65 && node-xmpp/node-xmpp-client#68.
