### PR TITLE
Update to nan 2.x for nodejs 4.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "bindings": "~1.2.1",
     "debug": "~2.2.0",
-    "nan": "~1.8.4"
+    "nan": "^2.1.0"
   },
   "devDependencies": {
     "grunt": "~0.4.2",


### PR DESCRIPTION
This is based on https://github.com/node-xmpp/node-stringprep/tree/nan2-astro but omits things that were changing the way the calls to icu work, some of which were breaking tests.

It also fixes one issue in `prepare` where the result string was being freed before it was returned which was causing the `leakcheck.js` test to fail.